### PR TITLE
Replace ephemeral subscriber queues with named queues.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@randomguys/eventbus",
+  "name": "@random-guys/eventbus",
   "version": "1.0.0",
   "description": "Event Bus service for service-service communication via RabbitMQ",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@random-guys/eventbus",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Event Bus service for service-service communication via RabbitMQ",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@random-guys/eventbus",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Event Bus service for service-service communication via RabbitMQ",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/subscriber.spec.ts
+++ b/src/subscriber.spec.ts
@@ -31,17 +31,17 @@ test('it throws if Event Bus methods are called before initializing Event Bus', 
 
   await expect(subscriber.close()).rejects.toThrow(INIT_EVENTBUS_ERROR);
 
-  await expect(subscriber.on(undefined, undefined, undefined)).rejects.toThrow(
-    INIT_EVENTBUS_ERROR,
-  );
+  await expect(
+    subscriber.on(undefined, undefined, undefined, undefined)
+  ).rejects.toThrow(INIT_EVENTBUS_ERROR);
   await expect(subscriber.consume(undefined, undefined)).rejects.toThrow(
-    INIT_EVENTBUS_ERROR,
+    INIT_EVENTBUS_ERROR
   );
   await expect(() => subscriber.acknowledgeMessage(undefined)).toThrow(
-    INIT_EVENTBUS_ERROR,
+    INIT_EVENTBUS_ERROR
   );
   await expect(() => subscriber.rejectMessage(undefined)).toThrow(
-    INIT_EVENTBUS_ERROR,
+    INIT_EVENTBUS_ERROR
   );
 });
 
@@ -54,7 +54,7 @@ test('it creates an AMQP connection and channel', async () => {
 test('it creates a new subscriber instance', () => {
   const newSubscriber = subscriber.create();
   expect(Object.getPrototypeOf(newSubscriber)).toBe(
-    Object.getPrototypeOf(subscriber),
+    Object.getPrototypeOf(subscriber)
   );
   expect(() => newSubscriber.getChannel()).toThrow(INIT_EVENTBUS_ERROR);
   expect(() => newSubscriber.getConnection()).toThrow(INIT_EVENTBUS_ERROR);
@@ -73,10 +73,16 @@ test('it listens on and gets data from an emitted event', async done => {
     const data = JSON.parse(message.content.toString());
     expect(data.topic).toBe('test.emit');
     expect(data.type).toBe('test');
+    subscriber.acknowledgeMessage(message);
     done();
   };
 
-  const result = await subscriber.on(TEST_EXCHANGE, 'test.emit', callback);
+  const result = await subscriber.on(
+    TEST_EXCHANGE,
+    'test.emit',
+    'LISTENER_QUEUE',
+    callback
+  );
   expect(result.consumerTag).toBeDefined();
 
   // emit mock event


### PR DESCRIPTION
In the previous version of `EventBus` listeners were bound to an ephemeral queue that was deleted immediately after the underlying connection closes. There were also no message delivery acknowledges i.e once an event emitter emits an event via an exchange, there are no subsequent checks on the receiving queues to know if the event was acknowledged and resolved by the listeners. This adhered to the fire and forget (pub-sub) principle/idea, however it this resulted in the following issues:

Firstly, for `n` instances of a particular app with a listener (think K8s pod or pm2 app with multiple instances), we will have `n` queues all listening to the same event. This causes an undesirable effect in which we get the same messages/event multiple times in the same app across separate instances.
Secondly, without any message acknowledges we risk losing important messages. This isn't ideal and defeats the purpose of the event bus.

This PR solves the two problems above by allowing the `.on()` subscriber method to recieve a `queueName` which will be bound to an exchange and will receive messages routed with a particular routing key. This queue `queueName` expects the message to be acknowledged by default unless an option object is passed that specifies otherwise. This way listeners on all instances of an app listening for a particular event will do so on a shared queue, thus preventing duplicate messages from being delivered.